### PR TITLE
fix several issues with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
-NAME = `cat ./main.go | grep "Name = " | cut -d" " -f4 | sed 's/[^"]*"\([^"]*\).*/\1/'`
-VERSION = `cat ./main.go | grep "Version = " | cut -d" " -f4 | sed 's/[^"]*"\([^"]*\).*/\1/'`
-DEPS = $(go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
+NAME = $(shell cat ./main.go | grep "Name = " | cut -d" " -f4 | sed 's/[^"]*"\([^"]*\).*/\1/')
+VERSION = $(shell cat ./main.go | grep "Version = " | cut -d" " -f4 | sed 's/[^"]*"\([^"]*\).*/\1/')
+DEPS = $(shell go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 
-all: deps build
+all: build
 
-deps:
+deps: Makefile
 	go get -d -v ./...
-	echo $(DEPS) | xargs -n1 go get -d
+	echo $(DEPS) | xargs -r -n1 go get -d
+	touch $@
 
-build:
+build: bin/$(NAME)
+
+bin/$(NAME): deps
 	@mkdir -p bin/
 	go build -o bin/$(NAME)
 
@@ -29,4 +32,7 @@ package: xcompile
 		echo $$f; \
 	done
 
-.PHONY: all deps build test xcompile package
+clean:
+	rm -rf bin build deps
+
+.PHONY: all build test xcompile package clean


### PR DESCRIPTION
- $DEPS did not get value
- set NAME and VERSION as make vars, looks better in output
- do not invoke got get via xargs if DEPS is empty
- fix make -j2 - interdependencies were broken (build was invoked before
  deps were fetched)
- run deps once, invalidated by Makefile changes
- add clean target
- add bin/$(NAME) to build deps, move build itself to different target
  to handle make deps
